### PR TITLE
Change the predicate function so that it doesn't have a trailing `is_`

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,11 +314,11 @@ end
 ```
 
 * The names of predicate functions (a function that return a boolean value)
-  should end in a question mark.
+  should have a trailing question mark rather than a leading `is_` or similar.
 
 ```Elixir
-def is_string?(var) do
-  # check if var is string
+def cool?(var) do
+  # checks if var is cool
 end
 ```
 


### PR DESCRIPTION
The point of having a trailing `?` is to avoid using traling `is_` (or `are_` or similar), amirite? :)

Also, I changed the example function from `string?` to `cool?` since I don't want anyone to get potentially confused since `is_binary/2` exists and does exactly that.