### PR TITLE
Make style coherent throughout the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,21 @@
 # Prelude
 
-> Liquid architecture. It's like jazz - you improvise, you work together, you play off each other, you make something, they make something. <br/>
+> Liquid architecture. It's like jazz - you improvise, you work together, you
+> play off each other, you make something, they make something. <br/>
 > -- Frank Gehry
 
-Style matters. Elixir has plenty of style but like all languages it can be stifled.
-Don't stifle the style.
+Style matters. Elixir has plenty of style but like all languages it can be
+stifled.  Don't stifle the style.
 
-**NOTE**: From here on out, you get a PR merged, you get added as a collaborator. People who have
-PRs merged have been added as collaborators.
+**NOTE**: From here on out, you get a PR merged, you get added as a
+collaborator. People who have PRs merged have been added as collaborators.
+
 
 # The Elixir Style Guide
 
-This is my attempt at starting a community style guide for Elixir. Please
-feel free to make pull requests and contribute. I really want Elixir to
-have as vibrant of a community as any language that's been around five
-times as long.
+This is my attempt at starting a community style guide for Elixir. Please feel
+free to make pull requests and contribute. I really want Elixir to have as
+vibrant of a community as any language that's been around five times as long.
 
 If you're looking for other projects to contribute to please see Elixir's wiki
 page with [list of projects] or [hex package manager site].
@@ -53,19 +54,20 @@ def some_function do
 end
 ```
 
-* Use Unix-style line endings. (\*BSD/Solaris/Linux/OSX users are covered by default,
-  Windows users have to be extra careful.)
+* Use Unix-style line endings. (\*BSD/Solaris/Linux/OSX users are covered by
+  default, Windows users have to be extra careful.)
 
-
-    * If you're using Git you might want to add the following
-    configuration setting to protect your project from Windows line
-    endings creeping in:
+    * If you're using Git you might want to add the following configuration
+      setting to protect your project from Windows line endings creeping in:
 
 ```bash
 $ git config --global core.autocrlf true
 ```
 
-* Use spaces around operators, after commas, colons and semicolons. Do not put spaces around matched pairs like brackets, parenthesis, etc. Whitespace might be (mostly) irrelevant to the Elixir runtime, but its proper use is the key to writing easily readable code.
+* Use spaces around operators, after commas, colons and semicolons. Do not put
+  spaces around matched pairs like brackets, parenthesis, etc. Whitespace might
+  be (mostly) irrelevant to the Elixir runtime, but its proper use is the key to
+  writing easily readable code.
 
 ```Elixir
 sum = 1 + 2
@@ -124,7 +126,9 @@ some_string
 |> String.strip
 ```
 
-While this is the preferred method, take into account that copy pasting multiline pipelines into IEX might result in a syntax error as IEX will evaluate the first line without realizing that the next line has a pipeline.
+While this is the preferred method, take into account that copy pasting
+multiline pipelines into IEX might result in a syntax error as IEX will evaluate
+the first line without realizing that the next line has a pipeline.
 
 * Use _bare_ variables in the first part of a function chain
 
@@ -249,8 +253,8 @@ quote do
 end
 ```
 
-* Optionally omit parentheses in function calls (outside a pipeline) when
-  the last argument is a function expression.
+* Optionally omit parentheses in function calls (outside a pipeline) when the
+  last argument is a function expression.
 
 ```Elixir
 # preferred
@@ -294,8 +298,7 @@ def some_function do
 end
 ```
 
-* Use `CamelCase` for modules.  (Keep acronyms like HTTP,
-  RFC, XML uppercase.)
+* Use `CamelCase` for modules (Keep acronyms like HTTP, RFC, XML uppercase).
 
 ```Elixir
 # not preferred
@@ -333,53 +336,52 @@ end
 ## Comments
 
 * Write self-documenting code and ignore the rest of this section. Seriously!
-* Use one space between the leading `#` character of the comment and the text
-  of the comment.
-* Comments longer than a word are capitalized and use punctuation. Use [one
-  space](http://en.wikipedia.org/wiki/Sentence_spacing) after periods.
+* Use one space between the leading `#` character of the comment and the text of
+  the comment.
+* Comments longer than a word are capitalized and use punctuation. Use
+  [one space](http://en.wikipedia.org/wiki/Sentence_spacing) after periods.
 
 ```Elixir
 # not preferred
 String.upcase(some_string) # Capitalize string.
 ```
 
-* Keep existing comments up-to-date. An outdated comment is worse than no comment
-at all.
-
-* Avoid writing comments to explain bad code. Refactor the code to
-  make it self-explanatory. (Do or do not - there is no try. --Yoda)
+* Keep existing comments up-to-date. An outdated comment is worse than no
+  comment at all.
+* Avoid writing comments to explain bad code. Refactor the code to make it
+  self-explanatory. (Do or do not - there is no try. --Yoda)
 
 ### Comment Annotations
 
-* Annotations should usually be written on the line immediately above
-  the relevant code.
+* Annotations should usually be written on the line immediately above the
+  relevant code.
 * The annotation keyword is followed by a colon and a space, then a note
   describing the problem.
-* If multiple lines are required to describe the problem, subsequent
-  lines should be indented two spaces after the `#`.
+* If multiple lines are required to describe the problem, subsequent lines
+  should be indented two spaces after the `#`.
 
-* In cases where the problem is so obvious that any documentation would
-  be redundant, annotations may be left at the end of the offending line
-  with no note. This usage should be the exception and not the rule.
+* In cases where the problem is so obvious that any documentation would be
+  redundant, annotations may be left at the end of the offending line with no
+  note. This usage should be the exception and not the rule.
 
 
-* Use `TODO` to note missing features or functionality that should be
-  added at a later date.
+* Use `TODO` to note missing features or functionality that should be added at a
+  later date.
 * Use `FIXME` to note broken code that needs to be fixed.
-* Use `OPTIMIZE` to note slow or inefficient code that may cause
-  performance problems.
-* Use `HACK` to note code smells where questionable coding practices
-  were used and should be refactored away.
-* Use `REVIEW` to note anything that should be looked at to confirm it
-  is working as intended. For example: `REVIEW: Are we sure this is how the
-  client does X currently?`
-* Use other custom annotation keywords if it feels appropriate, but be
-  sure to document them in your project's `README` or similar.
+* Use `OPTIMIZE` to note slow or inefficient code that may cause performance
+  problems.
+* Use `HACK` to note code smells where questionable coding practices were used
+  and should be refactored away.
+* Use `REVIEW` to note anything that should be looked at to confirm it is
+  working as intended. For example: `REVIEW: Are we sure this is how the client
+  does X currently?`
+* Use other custom annotation keywords if it feels appropriate, but be sure to
+  document them in your project's `README` or similar.
 
 ## Modules
 
-* Use one module per file unless the module is only used internally by
-  another module (such as a test.)
+* Use one module per file unless the module is only used internally by another
+  module (such as a test).
 * Use underscored file names for `CamelCase` module names.
 
 ```Elixir
@@ -416,32 +418,32 @@ end
 
 # Contributing
 
-It's my hope that this will become a central
-hub for community discussion on best
-practices in Elixir.
-Feel free to open tickets or send pull requests with improvements. Thanks in
-advance for your help!
+It's my hope that this will become a central hub for community discussion on
+best practices in Elixir. Feel free to open tickets or send pull requests with
+improvements. Thanks in advance for your help!
+
 
 # License
 
 ![Creative Commons License](http://i.creativecommons.org/l/by/3.0/88x31.png)
-This work is licensed under a [Creative Commons Attribution 3.0 Unported License](http://creativecommons.org/licenses/by/3.0/deed.en_US)
+This work is licensed under a
+[Creative Commons Attribution 3.0 Unported License](http://creativecommons.org/licenses/by/3.0/deed.en_US)
+
 
 # Attribution
+
 The structure of this guide, bits of example code, and many of the initial
 points made in this document were borrowed from the
-[Ruby community style guide](https://github.com/bbatsov/ruby-style-guide).
-A lot of things were applicable to Elixir and allowed me to get
-_some_ document out quicker to start the conversation.
+[Ruby community style guide](https://github.com/bbatsov/ruby-style-guide).  A
+lot of things were applicable to Elixir and allowed me to get _some_ document
+out quicker to start the conversation.
 
 
 # Spread the Word
 
-A community style guide is meaningless
-without the community's support.
-Please Tweet, star, and let any Elixir
-programmer know about this guide so
-they can contribute.
+A community style guide is meaningless without the community's support.  Please
+Tweet, star, and let any Elixir programmer know about this guide so they can
+contribute.
 
 [list of projects]: https://github.com/elixir-lang/elixir/wiki/Projects
 [hex package manager site]: https://hex.pm/packages


### PR DESCRIPTION
After all, this is a **style** guide! I feel like a consistent and coherent README makes a really good impression to new contributors, and maybe it even makes them happier to contribute :).

I'm willing to send also a PR with a `CONTRIBUTING.md` file so that new contributors can catch up with the style suggested in the README.

Changes (from the commit message):

- Wrapped all the lines at the 80th column
- Added some periods here and there
- Added two newlines before each `<h1>`