### PR TITLE
indent multiline pipelines on the right side of an `=`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Prelude
 
-> Liquid architecture. It's like jazz - you improvise, you work together, you
+> Liquid architecture. It's like jazz — you improvise, you work together, you
 > play off each other, you make something, they make something. <br/>
-> -- Frank Gehry
+> —Frank Gehry
 
 Style matters. Elixir has plenty of style but like all languages it can be
 stifled.  Don't stifle the style.
@@ -65,7 +65,7 @@ $ git config --global core.autocrlf true
 ```
 
 * Use spaces around operators, after commas, colons and semicolons. Do not put
-  spaces around matched pairs like brackets, parenthesis, etc. Whitespace might
+  spaces around matched pairs like brackets, parentheses, etc. Whitespace might
   be (mostly) irrelevant to the Elixir runtime, but its proper use is the key to
   writing easily readable code.
 
@@ -111,7 +111,7 @@ def some_function([first|rest]) do
 end
 ```
 
-* Use the pipeline operator ( |> ) to chain functions together
+* Use the pipeline operator (`|>`) to chain functions together
 
 ```Elixir
 # not preferred
@@ -349,7 +349,7 @@ String.upcase(some_string) # Capitalize string.
 * Keep existing comments up-to-date. An outdated comment is worse than no
   comment at all.
 * Avoid writing comments to explain bad code. Refactor the code to make it
-  self-explanatory. (Do or do not - there is no try. --Yoda)
+  self-explanatory. ("Do — or do not — there is no try." —Yoda)
 
 ### Comment Annotations
 

--- a/README.md
+++ b/README.md
@@ -125,10 +125,12 @@ some_string
 |> String.downcase
 |> String.strip
 
-# Multiline pipelines on the right side of a pattern match should be indented to below the pattern match
-sanitized_string = some_string
-                   |> String.downcase
-                   |> String.strip
+# Multiline pipelines on the right side of a pattern match
+# should be indented on a newline
+sanitized_string =
+  some_string
+  |> String.downcase
+  |> String.strip
 ```
 
 While this is the preferred method, take into account that copy pasting

--- a/README.md
+++ b/README.md
@@ -140,19 +140,13 @@ the first line without realizing that the next line has a pipeline.
 ```Elixir
 # THE WORST!
 # This actually parses as: String.strip( "nope" |> String.downcase )
-String.strip "nope"
-|> String.downcase
+String.strip "nope" |> String.downcase
 
 # not preferred
-String.strip(some_string)
-|> String.downcase
-|> String.codepoints
+String.strip(some_string) |> String.downcase |> String.codepoints
 
 # preferred
-some_string
-|> String.strip
-|> String.downcase
-|> String.codepoints
+some_string |> String.strip |> String.downcase |> String.codepoints
 ```
 
 * Avoid trailing whitespace.

--- a/README.md
+++ b/README.md
@@ -124,6 +124,11 @@ some_string |> String.downcase |> String.strip
 some_string
 |> String.downcase
 |> String.strip
+
+# Multiline pipelines on the right side of a pattern match should be indented to below the pattern match
+sanitized_string = some_string
+                   |> String.downcase
+                   |> String.strip
 ```
 
 While this is the preferred method, take into account that copy pasting
@@ -134,14 +139,20 @@ the first line without realizing that the next line has a pipeline.
 
 ```Elixir
 # THE WORST!
-# This actually parses as String.strip( "nope" |> String.downcase ).
-String.strip "nope" |> String.downcase
+# This actually parses as: String.strip( "nope" |> String.downcase )
+String.strip "nope"
+|> String.downcase
 
 # not preferred
-String.strip(some_string) |> String.downcase |> String.codepoints
+String.strip(some_string)
+|> String.downcase
+|> String.codepoints
 
 # preferred
-some_string |> String.strip |> String.downcase |> String.codepoints
+some_string
+|> String.strip
+|> String.downcase
+|> String.codepoints
 ```
 
 * Avoid trailing whitespace.


### PR DESCRIPTION
Adds an example of indenting a multiline pipeline when it occurs on the right-hand side of a pattern match.

(Also a little punctuation cleanup.)