### PR TITLE
Adding example of calling a function with no args

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,12 @@ f(3 + 2) + 1
 
 ```elixir
 # not preferred
+f
+
+# preferred
+f()
+
+# not preferred
 f 3
 
 # preferred


### PR DESCRIPTION
The preferred method is to include the parens, e.g. `f()` vs `f`.