### PR TITLE
Add string matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -551,6 +551,16 @@ end
 
 ## Strings
 
+Match strings using the string concatenator rather than binary patterns:
+
+```elixir
+# not preferred
+<<"my"::utf8, _rest>> = "my string"
+
+# preferred
+"my" <> _rest = "my string"
+```
+
 ## Regular Expressions
 
 ## Metaprogramming

--- a/README.md
+++ b/README.md
@@ -551,7 +551,7 @@ end
 
 ## Strings
 
-Match strings using the string concatenator rather than binary patterns:
+ * Match strings using the string concatenator rather than binary patterns:
 
 ```elixir
 # not preferred


### PR DESCRIPTION
As just discussed in the #elixir-lang IRC channel: We should match string using the concatenator rather than binary matching.

@josevalim approves :)