### PR TITLE
Add some guidelines on exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -544,6 +544,35 @@ end
 
 ## Exceptions
 
+  * Make exception names end with a trailing `Error`.
+
+```elixir
+# not preferred
+defmodule BadHTTPCode do
+  defexception [:message]
+end
+
+defmodule BadHTTPCodeException do
+  defexception [:message]
+end
+
+# preferred
+defmodule BadHTTPCodeError do
+  defexception [:message]
+end
+```
+
+  * Use lowercase error messages when raising exceptions, with no trailing
+    punctuation.
+
+```elixir
+# not preferred
+raise ArgumentError, "This is not valid."
+
+# preferred
+raise ArgumentError, "this is not valid"
+```
+
 ## Collections
 
 ## Strings


### PR DESCRIPTION
I added two guidelines:

- exception names should end with a trailing `Error`
- exception messages should be lowercase with no trailing punctuation