### PR TITLE
Specify how to indent the do: syntax in functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,30 @@ def some_function([first|rest]) do
 end
 ```
 
+* If you use the `do:` syntax with functions and the line that makes up the
+  function body is long, put the `do:` on a new line indented one level more
+  than the previous line.
+
+```elixir
+def some_function(args),
+  do: Enum.map(args, fn(arg) -> arg <> " is on a very long line!" end)
+```
+
+When you use the convention above and you have more than one function clause using the `do:` syntax, put the `do:` on a new line for each function clause:
+
+```elixir
+# not preferred
+def some_function([]), do: :empty
+def some_function(_),
+  do: :very_long_line_here
+
+# preferred
+def some_function([]),
+  do: :empty
+def some_function(_),
+  do: :very_long_line_here
+```
+
 * If you have more than one multi-line `def`s do not use single-line `def`s.
 
 ```elixir


### PR DESCRIPTION
I see this in most `elixir-lang/*` repositories, so I guess it makes sense to add it in the style guide :). Let me know what you think!