### PR TITLE
Update recommended casing for modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,14 +373,14 @@ def some_function(_),
   end
   ```
 
-* Use `CamelCase` for modules (keep acronyms like HTTP, RFC, XML uppercase).
+* Use `PascalCase` for modules (keep acronyms like HTTP, RFC, XML uppercase).
 
   ```elixir
   # not preferred
   defmodule Somemodule do
     ...
   end
-
+  
   defmodule Some_Module do
     ...
   end


### PR DESCRIPTION
Update recommended casing for modules from `CamelCase` to `PascalCase`. `CamelCase` always starts with a lower case letter (fooBar) whereas `PascalCase` always begins with a capital letter (FooBar).