### PR TITLE
Parentheses with anonymous function arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,9 @@ def some_function(_),
 
 ## Syntax
 
-* Use parentheses when you have arguments, no parentheses when you don't.
+* Use parentheses when you have arguments, no parentheses when you don't. This
+  preference holds for both named and anonymous functions. For anonymous
+  functions, it's OK to omit parentheses when there is a single argument.
 
   ```elixir
   # not preferred
@@ -221,6 +223,9 @@ def some_function(_),
     # body omitted
   end
 
+  some_function = fn arg1, arg2 -> result end
+  some_function = fn () -> result end
+
   # preferred
   def some_function(arg1, arg2) do
     # body omitted
@@ -229,6 +234,11 @@ def some_function(_),
   def some_function do
     # body omitted
   end
+
+  some_function = fn (arg1, arg2) -> result end
+  some_function = fn (arg1) -> result end
+  some_function = fn arg1 -> result end
+  some_function = fn -> result end
   ```
 
 * Never use `do:` for multi-line `if/unless`.
@@ -380,7 +390,7 @@ def some_function(_),
   defmodule Somemodule do
     ...
   end
-  
+
   defmodule Some_Module do
     ...
   end

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ If you're looking for other projects to contribute to please see the
 
 ```elixir
 def some_function(args),
-  do: Enum.map(args, fn(arg) -> arg <> " is on a very long line!" end)
+  do: Enum.map(args, fn (arg) -> arg <> " is on a very long line!" end)
 ```
 
 When you use the convention above and you have more than one function clause
@@ -342,12 +342,12 @@ def some_function(_),
 
   ```elixir
   # preferred
-  Enum.reduce(1..10, 0, fn x, acc ->
+  Enum.reduce(1..10, 0, fn (x, acc) ->
     x + acc
   end)
 
   # also preferred
-  Enum.reduce 1..10, 0, fn x, acc ->
+  Enum.reduce 1..10, 0, fn (x, acc) ->
     x + acc
   end
   ```


### PR DESCRIPTION
Hi there!

I noticed that the style guide has a preference for parentheses when there are arguments to named functions, but doesn't mention anonymous functions. One might take the position that we should be consistent in our treatment of arguments to both types of functions, so this pull request makes that consistency explicit.

I included a concession (stating that no parentheses are OK) for the case that there is a single argument to an anonymous function, as most of the code I've seen allows for that style, perhaps for its expediency. 

I then updated a few of the examples in the guide to be consistent with this style.

Please let me know what you think! Thank you for this excellent resource!