### PR TITLE
Revert "Remove extraneous link to the Ruby style guide"

### DIFF
--- a/README.md
+++ b/README.md
@@ -825,3 +825,4 @@ Please Tweet, star, and let any Elixir programmer know about
 [Elixir]: http://elixir-lang.org
 [Hex]: https://hex.pm/packages
 [license]: http://creativecommons.org/licenses/by/3.0/deed.en_US
+[Ruby community style guide]: https://github.com/bbatsov/ruby-style-guide


### PR DESCRIPTION
This reverts commit 27c8a290b5b0404c8551060e71e9b71cade1fbb3.

There was no particular reason to have removed this link.